### PR TITLE
Update the name and all hyperlinks to the repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,9 @@ An open-source Python library to make preprocessing of RNAseq files more conveni
 
 Circle CI Status of master branch: |circlecibuild|
 
-.. |circlecibuild| image:: https://circleci.com/gh/jpalpant/jarvis-lab-rnaseq-flow.png?style=shield
+.. |circlecibuild| image:: https://circleci.com/gh/jpalpant/rnaseqflow.png?style=shield
 
-See the lastest build status on `CircleCI <https://circleci.com/gh/jpalpant/jarvis-lab-rnaseq-flow/tree/master>`_
+See the lastest build status on `CircleCI <https://circleci.com/gh/jpalpant/rnaseqflow/tree/master>`_
 
 Complete documentation available on `Read the Docs <https://rnaseqflow.readthedocs.org>`_
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 You can checkout the latest development version from Github repository with the
 following command::
 
-	git clone https://github.com/jpalpant/jarvis-lab-rnaseq-flow
+	git clone https://github.com/jpalpant/rnaseqflow
 You can install rnaseqflow with pip::
 
 	pip install -U rnaseqflow

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -25,8 +25,8 @@ request support for a specific operation, request a feature, or report a bug, pl
 at the GitHub repository below.  
 
 GitHub repository:
-`jarvis-lab-rnaseq-flow <https://github.com/jpalpant/jarvis-lab-rnaseq-flow>`_
+`jarvis-lab-rnaseq-flow <https://github.com/jpalpant/rnaseqflow>`_
 
 Circle CI Status of master branch: |circlecibuild|
 
-.. |circlecibuild| image:: https://circleci.com/gh/jpalpant/jarvis-lab-rnaseq-flow.png?style=shield
+.. |circlecibuild| image:: https://circleci.com/gh/jpalpant/rnaseqflow.png?style=shield


### PR DESCRIPTION
The name and GitHub URL of the repository recently was changed from
jarvis-lab-rnaseq-flow to simply rnaseqflow - this changed needed to be
reflected in anything that relied on a direct GitHub URL.
